### PR TITLE
lesSSBdata: rm lines that are irrelevant

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,18 @@ Så inkluderes kjørefilen (da kjøres alle makroene):
 
 ## Kjøre tilrettelegging av innbyggertall fra SSB
 
-Inkludere makro-filen i prosjektet:
+Følgende kode ble kjørt for å legge til innbyggertallene 1. januar 2018:
 ```
 %let kodebane = \\hn.helsenord.no\unn-avdelinger\skde.avd\Analyse\Data\SAS\Tilrettelegging\saskoder\ssb\;
 %include "&kodebane.lesSSBdata.sas";
-```
 
-Kjør makroen:
-```
-%lesSSBdata(aar=2018, utdata = TEST, bydel = 0);
+%lesSSBdata(aar=2018, utdata = bydel, bydel = 1);
+
+%lesSSBdata(aar=2018, utdata = kommune, bydel = 0);
+
+data innbygg.innb_2004_2017_bydel_allebyer;
+set innbygg.innb_2004_2016_bydel_allebyer kommune bydel;
+run;
 ```
 
 Se ellers [SKDE-dokumentasjon](https://skde-analyse.github.io/dokumentasjon/tilrettelegging-av-data.html#tilrettelegging-av-innbyggertall-fra-ssb).

--- a/ssb/lesSSBdata.sas
+++ b/ssb/lesSSBdata.sas
@@ -42,13 +42,30 @@ set &utdata;
 
 /* Lage bydel som numerisk variabel */
 %if &bydel ne 0 %then %do;
-where substr(region,5,2) ne '00';
 
-/*Lage bydelsvariabel og endre den til numerisk*/
+/* 
+Ta ut totaltallene for disse kommunene 
+Ta ut linjer der antall innbyggere er null
+*/
+where (substr(region,5,2) ne '00') and (Personer > 0);
+
+/* Lage bydelsvariabel og endre den til numerisk */
 bydel_string=substr(region,1,6);
 bydel=input(bydel_string,6.);
 
 drop bydel_string;
+%end;
+%else %do;
+/*
+Ta ut Oslo, Bergen, Trondheim og Stavanger fra kommunefil 
+'0301'=Oslo, '1103'=Stavanger, '1201'=Bergen, 
+'1601'=Trondheim før 2018, '5001'=Trondheim fra 2018
+Ta ut linjer der antall innbyggere er null
+*/
+where (not (substr(region,1,4) in ('0301', '1103', '1201', '1601', '5001'))) and (Personer > 0);
+
+bydel = .;
+
 %end;
 
 
@@ -62,7 +79,10 @@ drop komnr_string;
 /* Fjerne " år" i alder og endre den til numerisk */
 alder_string = substr(alder, 1, length(alder)-3);
 drop alder;
-alder = input(alder_string, 3.);
+
+alder_num = input(alder_string, 4.);
+
+rename alder_num = alder;
 
 drop alder_string;
 
@@ -73,6 +93,11 @@ else if kjonn = "Kvinner" then ErMann = 0;
 innbyggere = Personer;
 
 drop kjonn region Personer;
+
+/* 
+Bruker antall innbyggere 1. januar for år X + 1 som innbyggertall for år X 
+*/
+aar = %eval(&aar - 1);
 
 run;
 


### PR DESCRIPTION
- Total numbers for Oslo, Bergen, Stavanger and Trondheim
- If number of inhabitants is zero.
- Define `aar` variable in data set as `&aar - 1`.
- Fixed bug, `alder` was lost.
- Updated README